### PR TITLE
GStreamer backend improvements

### DIFF
--- a/t_modules/t_gstreamer.py
+++ b/t_modules/t_gstreamer.py
@@ -53,10 +53,22 @@ def player3(tauon):  # GStreamer
             # Create main "playbin" pipeline thingy for simple playback
             self.pl = Gst.ElementFactory.make("playbin", "player")
 
+            # Set up output sink
+            if prefs.gst_sink:
+                sink = Gst.ElementFactory.make(prefs.gst_sink, "output")
+
+                sink_props = prefs.gst_sink_props.split(';')
+                for entry in sink_props:
+                    lhs, rhs = entry.split('=')
+                    sink.set_property(lhs, rhs)
+
+                # Pipe playbin -> output sink
+                self.pl.set_property('audio-sink', sink)
+
             # Set callback for the main callback loop
             GLib.timeout_add(500, self.main_callback)
 
-            # self.pl.connect("about-to-finish", self.about_to_finish)
+            self.pl.connect("about-to-finish", self.about_to_finish)
 
             self.mainloop.run()
 

--- a/t_modules/t_gstreamer.py
+++ b/t_modules/t_gstreamer.py
@@ -80,7 +80,7 @@ def player3(tauon):  # GStreamer
             # (player) -> [(volume) -> (output)]
 
             # Set callback for the main callback loop
-            GLib.timeout_add(500, self.main_callback)
+            GLib.timeout_add(50, self.main_callback)
 
             # self.playbin.connect("about-to-finish", self.about_to_finish)
 
@@ -329,4 +329,3 @@ def player3(tauon):  # GStreamer
 
     # Notify main thread we have closed cleanly
     player.exit()
-

--- a/tauon.py
+++ b/tauon.py
@@ -2388,6 +2388,8 @@ def save_prefs():
     cf.update_value("disconnect-device-pause", prefs.dc_device_setting)
     cf.update_value("use-short-buffering", prefs.short_buffer)
 
+    cf.update_value("gst-output", prefs.gst_output)
+
     cf.update_value("tag-editor-name", prefs.tag_editor_name)
     cf.update_value("tag-editor-target", prefs.tag_editor_target)
 

--- a/tauon.py
+++ b/tauon.py
@@ -847,6 +847,9 @@ class Prefs:    # Used to hold any kind of settings
         self.playback_follow_cursor = False
         self.short_buffer = False
 
+        self.gst_sink = ""
+        self.gst_sink_props = ""
+
         self.art_bg = False
         self.art_bg_stronger = 1
         self.art_bg_opacity = 10
@@ -2474,6 +2477,9 @@ def load_prefs():
     prefs.mono = cf.sync_add("bool", "force-mono", prefs.mono, "BASS only.")
     prefs.dc_device_setting = cf.sync_add("string", "disconnect-device-pause", prefs.dc_device_setting, "Can be \"auto\", \"on\" or \"off\". BASS only.")
     prefs.short_buffer = cf.sync_add("bool", "use-short-buffering", prefs.short_buffer, "BASS only.")
+
+    prefs.gst_sink = cf.sync_add("string", "sink-name", prefs.gst_sink, "GStreamer Only. Leave blank to allow GStreamer to decide.")
+    prefs.gst_sink_props = cf.sync_add("string", "sink-props", prefs.gst_sink_props, "GStreamer Only. Format is 'property1=value;property2=value;...'")
 
     if prefs.dc_device_setting == 'on':
         prefs.dc_device = True

--- a/tauon.py
+++ b/tauon.py
@@ -847,8 +847,7 @@ class Prefs:    # Used to hold any kind of settings
         self.playback_follow_cursor = False
         self.short_buffer = False
 
-        self.gst_sink = ""
-        self.gst_sink_props = ""
+        self.gst_output = "rgvolume pre-amp=-2 fallback-gain=-6 ! autoaudiosink"
 
         self.art_bg = False
         self.art_bg_stronger = 1
@@ -2478,8 +2477,7 @@ def load_prefs():
     prefs.dc_device_setting = cf.sync_add("string", "disconnect-device-pause", prefs.dc_device_setting, "Can be \"auto\", \"on\" or \"off\". BASS only.")
     prefs.short_buffer = cf.sync_add("bool", "use-short-buffering", prefs.short_buffer, "BASS only.")
 
-    prefs.gst_sink = cf.sync_add("string", "sink-name", prefs.gst_sink, "GStreamer Only. Leave blank to allow GStreamer to decide.")
-    prefs.gst_sink_props = cf.sync_add("string", "sink-props", prefs.gst_sink_props, "GStreamer Only. Format is 'property1=value;property2=value;...'")
+    prefs.gst_output = cf.sync_add("string", "gst-output", prefs.gst_output, "GStreamer output pipeline specification")
 
     if prefs.dc_device_setting == 'on':
         prefs.dc_device = True


### PR DESCRIPTION
This PR adds the ability to configure the GStreamer output pipeline

It adds a new option to the `[audio]` section of the configuration file, `gst-output`, which allows the user to tweak their audio output pipeline. For example, `rgvolume pre-amp=-2 fallback-gain=-6 ! jackaudiosink client-name=tauon` would apply replaygain in album mode with custom pre-amp and fallback gain and then output audio via JACK.

In addition to the more outward change, this also drastically reduces the GStreamer polling rate which makes volume control seem more responsive.