### PR TITLE
Add `album_artist` to scrobble

### DIFF
--- a/tauon.py
+++ b/tauon.py
@@ -6518,7 +6518,7 @@ class LastFMapi:
         try:
             if title != "" and artist != "":
                 if album != "":
-                    if album_artist != artist:
+                    if album_artist and album_artist != artist:
                         self.network.scrobble(artist=artist, title=title, album=album, album_artist=album_artist, timestamp=timestamp)
                     else:
                         self.network.scrobble(artist=artist, title=title, album=album, timestamp=timestamp)

--- a/tauon.py
+++ b/tauon.py
@@ -6510,6 +6510,7 @@ class LastFMapi:
         title = track_object.title
         album = track_object.album
         artist = get_artist_strip_feat(track_object)
+        album_artist = track_object.album_artist
 
         print("submitting scrobble...")
 
@@ -6517,7 +6518,10 @@ class LastFMapi:
         try:
             if title != "" and artist != "":
                 if album != "":
-                    self.network.scrobble(artist=artist, title=title, album=album, timestamp=timestamp)
+                    if album_artist != artist:
+                        self.network.scrobble(artist=artist, title=title, album=album, album_artist=album_artist, timestamp=timestamp)
+                    else:
+                        self.network.scrobble(artist=artist, title=title, album=album, timestamp=timestamp)
                 else:
                     self.network.scrobble(artist=artist, title=title, timestamp=timestamp)
                 # print('Scrobbled')


### PR DESCRIPTION
With apologies to the maintainer - should resolve #510?

> I have some tracks in my library with differing track Artists and Album Artists. This doesn't seem to be scrobbled (on last.fm, the track is linked to an album under the Artist's name, but not the Album Artist's name).

To describe this in more detail: 
![image](https://user-images.githubusercontent.com/25379179/115818387-ab719100-a3ca-11eb-9d3c-8c9df088d79f.png)
This track is off of the album "works.thE", with the album artist being "Diverse System". When you click "Go to album" on the scrobble, it takes you here:
![image](https://user-images.githubusercontent.com/25379179/115818357-972d9400-a3ca-11eb-84f3-7b62a3d797ff.png)
The scrobble is missing the "Album Artist" property. This fixes that. I think. (It works on my system, at least...)
