### PR TITLE
Add missing pygobject dependency to requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,5 +11,4 @@ setproctitle
 tekore
 pulsectl
 mutagen
-
-
+PyGObject


### PR DESCRIPTION
While I was testing #560 I noticed that one dependency is missing from `requirements.txt`, so I added it.