### PR TITLE
Change `extra/repo-install.sh` to clone `extra/tauonmb.*` intead of changing them directly

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,4 +26,5 @@ pygettext.py
 lib/
 *.DS_Store
 dist/
+*.tmp.*
 

--- a/extra/repo-install.sh
+++ b/extra/repo-install.sh
@@ -1,20 +1,12 @@
 #!/bin/bash
 #
 # A script for the lazy folk and probably a butchering of git.
-#
-# Run this script once you have ALL the dependencies set up.
-#
-# If you're running it for the 1st time (and in order to appease my OCD), the repository itself should
-# probably be clean, as in:
-# -------------------------------------------------------------------------------------------------------
+# Run this script once you have ALL the dependencies set up and updated; this also include dependencies outside of Python, like 'opusfile-devel' on Fedora. Either way, the debug message pointing out what is missing when compiling PHAzOR (line #16) helps you find out what is needed. Usually those packages have similar enough names to be found quite easily by your package manager of choice.
+# The script below installs the TauonMusicBox repo as a desktop app by cloning files into temporary ones and changing+deploying them; lines #18 to #23. I did it because I was too lazy to learn RPM packaging :B
+# If you're running it for the very first time (and just to be on the safe side), then the repository itself should probably be cleansed, as in:
+#   ----------------------------------
 #   git reset --hard && git clean -dfx
-# -------------------------------------------------------------------------------------------------------
-#
-# It wonkly deploys the TauonMusicBox repo as a desktop app by modifying the existing files. By doing so
-# we use the app directly from the repo... I did it because I was too lazy to learn RPM packaging :B
-#
-# This and 'repo-uninstall-as-is.sh' are best used on a repo with --depth=1; one you will NOT work on.
-#
+#   ----------------------------------
 # Thank you.
 
 RepoDir=$(realpath $(dirname "$0")/..)
@@ -22,15 +14,17 @@ cd $RepoDir
 
 rm -f lib/*
 sh compile-phazor.sh || exit 0
-sed -i "s+/opt/tauon-music-box+sh $RepoDir/extra+g" extra/tauonmb.desktop
-sed -i '1a cd $(realpath $(dirname "$0")/..)' extra/tauonmb.sh
-sed -i "s+/opt/tauon-music-box+$RepoDir+g" extra/tauonmb.sh
 
-install -Dm755 extra/tauonmb.desktop ~/.local/share/applications/tauonmb.desktop
-install -Dm644 extra/tauonmb-symbolic.svg ~/.local/share/icons/hicolor/scalable/apps/tauonmb-symbolic.svg
-install -Dm644 extra/tauonmb.svg ~/.local/share/icons/hicolor/scalable/apps/tauonmb.svg
+cp -f extra/tauonmb.{,tmp.}desktop
+cp -f extra/tauonmb.{,tmp.}sh
 
-# This lines uses sudo to update your desktop apps list so you can open it from the menu as soon as it is
-# ready.
-# I recommend never running the script itself as sudo, though.
+sed -i "s+/opt/tauon-music-box/tauonmb+sh $RepoDir/extra/tauonmb.tmp+g" extra/tauonmb.tmp.desktop
+sed -i '1a cd $(realpath $(dirname "$0")/..)' extra/tauonmb.tmp.sh
+sed -i "s+/opt/tauon-music-box+$RepoDir+g" extra/tauonmb.tmp.sh
+
+install -Dm755 extra/tauonmb.tmp.desktop ~/.local/share/applications/tauonmb.desktop
+install -Dm644 extra/tauonmb{,-symbolic}.svg ~/.local/share/icons/hicolor/scalable/apps/
+
+# This lines uses sudo to update your desktop apps list so you can open it from the menu as soon as it is ready.
+# NEVER run the script itself as sudo, though.
 sudo update-desktop-database

--- a/extra/repo-uninstall.sh
+++ b/extra/repo-uninstall.sh
@@ -1,10 +1,6 @@
 #!/bin/bash
 #
-# Uninstalls the app-repo, keeping the user-data and becoming just the good ol' repo
-
-RepoDir=$(realpath $(dirname "$0")/..)
-cd $RepoDir
-
-git reset --hard
+# Removes the '.desktop' and '.svg's files from their deployed location.
 
 rm -f ~/.local/share/{applications/tauonmb.desktop,icons/hicolor/scalable/apps/tauonmb{.svg,-symbolic.svg}}
+sudo update-desktop-database

--- a/extra/repo-uninstall.sh
+++ b/extra/repo-uninstall.sh
@@ -1,6 +1,9 @@
 #!/bin/bash
 #
-# Removes the '.desktop' and '.svg's files from their deployed location.
+# Removes everything 'extra/repo-install.sh' creates.
 
-rm -f ~/.local/share/{applications/tauonmb.desktop,icons/hicolor/scalable/apps/tauonmb{.svg,-symbolic.svg}}
+RepoDir=$(realpath $(dirname "$0")/..)
+cd $RepoDir
+
+rm -f extra/tauonmb.tmp.* ~/.local/share/{applications/tauonmb.desktop,icons/hicolor/scalable/apps/tauonmb{.svg,-symbolic.svg}}
 sudo update-desktop-database


### PR DESCRIPTION
So it leaves the tracked files alone.

I also took the liberty to add the `*.tmp.*` line in `.gitignore`. Is that fine? I'll change it back if is not.

I added it in just in case there is no change in the original `extra/tauonmb.*` files and the user wants to update their repo without worrying about them. Either way, if the user would just run the script again, the `*.tmp.*` files will be overwritten and any problem originated from keeping the temporary files between updates will be gone.

Original idea taken from #667 comment section.