### PR TITLE
Instead of deleting `tauonmb.tmp.sh`, track `tauonmb-alt.sh`

### DIFF
--- a/extra/repo-install.sh
+++ b/extra/repo-install.sh
@@ -40,6 +40,7 @@ cp -f extra/tauonmb.{,tmp.}desktop
 sed -i "s+/opt/tauon-music-box/tauonmb+sh $RepoDir/extra/tauonmb-alt+g" extra/tauonmb.tmp.desktop
 
 mkdir -p $ShareDir/{applications,icons/hicolor/scalable/apps}
+[ -e $ShareDir/applications/tauonmb.desktop ] && rm $ShareDir/applications/tauonmb.desktop
 install -Dm755 extra/tauonmb.tmp.desktop $ShareDir/applications/tauonmb.desktop
 install -Dm644 extra/tauonmb{,-symbolic}.svg $ShareDir/icons/hicolor/scalable/apps/
 

--- a/extra/repo-install.sh
+++ b/extra/repo-install.sh
@@ -36,17 +36,14 @@ sh compile-phazor.sh
 python3 compile-translations.py
 
 cp -f extra/tauonmb.{,tmp.}desktop
-cp -f extra/tauonmb.{,tmp.}sh
 
-sed -i "s+/opt/tauon-music-box/tauonmb+sh $RepoDir/extra/tauonmb.tmp+g" extra/tauonmb.tmp.desktop
-sed -i '1a cd $(realpath $(dirname "$0")/..)' extra/tauonmb.tmp.sh
-sed -i "s+/opt/tauon-music-box+$RepoDir+g" extra/tauonmb.tmp.sh
+sed -i "s+/opt/tauon-music-box/tauonmb+sh $RepoDir/extra/tauonmb-alt+g" extra/tauonmb.tmp.desktop
 
 mkdir -p $ShareDir/{applications,icons/hicolor/scalable/apps}
 install -Dm755 extra/tauonmb.tmp.desktop $ShareDir/applications/tauonmb.desktop
 install -Dm644 extra/tauonmb{,-symbolic}.svg $ShareDir/icons/hicolor/scalable/apps/
 
-rm -fR extra/tauonmb.tmp.*
+rm -fR extra/tauonmb.tmp.desktop
 
 # This lines uses sudo to update your desktop apps list so you can
 # open it from the menu as soon as it is ready.

--- a/extra/tauonmb-alt.sh
+++ b/extra/tauonmb-alt.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+cd $(realpath $(dirname "$0")/..)
+
+if [ "$1" == "--no-start" ]; then
+	if [ "$2" == "--play" ]; then curl http://localhost:7813/play/
+	elif [ "$2" == "--play-pause" ]; then curl http://localhost:7813/playpause/
+	elif [ "$2" == "--pause" ]; then curl http://localhost:7813/pause/
+	elif [ "$2" == "--stop" ]; then curl http://localhost:7813/stop/
+	elif [ "$2" == "--next" ]; then curl http://localhost:7813/next/
+	elif [ "$2" == "--previous" ]; then curl http://localhost:7813/previous/
+	else python3 ../tauon.py "$@";
+	fi
+else
+	python3 ../tauon.py "$@"
+fi

--- a/extra/tauonmb-alt.sh
+++ b/extra/tauonmb-alt.sh
@@ -12,5 +12,5 @@ if [ "$1" == "--no-start" ]; then
 	else python3 ../tauon.py "$@";
 	fi
 else
-	python3 ../tauon.py "$@"
+	python3 tauon.py "$@"
 fi

--- a/extra/tauonmb-alt.sh
+++ b/extra/tauonmb-alt.sh
@@ -9,7 +9,7 @@ if [ "$1" == "--no-start" ]; then
 	elif [ "$2" == "--stop" ]; then curl http://localhost:7813/stop/
 	elif [ "$2" == "--next" ]; then curl http://localhost:7813/next/
 	elif [ "$2" == "--previous" ]; then curl http://localhost:7813/previous/
-	else python3 ../tauon.py "$@";
+	else python3 tauon.py "$@";
 	fi
 else
 	python3 tauon.py "$@"


### PR DESCRIPTION
In reality, the parsed script can't be temporary.

#674 made so running `extra/repo-install.sh` deletes all .tmp files after parsing them.
After `tauonmb.tmp.desktop` and the .svgs are installed to `.local/shared`, the desktop launcher will still point to the parsed script.
Without it, Tauon won't open if installed using `repo-install.sh`.

So it's better to have `extra/tauonmb-alt.sh` tracked.

_Addendum: repo-install also didn't overwrite the deployed desktop app, it does now._