### PR TITLE
Removes the need for `tauonmb.tmp.sh`

### DIFF
--- a/extra/repo-install.sh
+++ b/extra/repo-install.sh
@@ -36,17 +36,14 @@ sh compile-phazor.sh
 python3 compile-translations.py
 
 cp -f extra/tauonmb.{,tmp.}desktop
-cp -f extra/tauonmb.{,tmp.}sh
 
-sed -i "s+/opt/tauon-music-box/tauonmb+sh $RepoDir/extra/tauonmb.tmp+g" extra/tauonmb.tmp.desktop
-sed -i '1a cd $(realpath $(dirname "$0")/..)' extra/tauonmb.tmp.sh
-sed -i "s+/opt/tauon-music-box+$RepoDir+g" extra/tauonmb.tmp.sh
+sed -i -e "s+/opt/tauon-music-box/tauonmb.sh %U+python3 $RepoDir/tauon.py+g" -e "s+/opt/tauon-music-box/tauonmb.sh --no-start +curl http://localhost:7813/+g" -e "s+--play-pause+playpause/+g" -e "s+--previous+previous/+g" -e "s+--next+next/+g" -e "s+--stop+stop/+g" extra/tauonmb.tmp.desktop
 
 mkdir -p $ShareDir/{applications,icons/hicolor/scalable/apps}
 install -Dm755 extra/tauonmb.tmp.desktop $ShareDir/applications/tauonmb.desktop
 install -Dm644 extra/tauonmb{,-symbolic}.svg $ShareDir/icons/hicolor/scalable/apps/
 
-rm -fR extra/tauonmb.tmp.*
+rm -fR extra/tauonmb.tmp.desktop
 
 # This lines uses sudo to update your desktop apps list so you can
 # open it from the menu as soon as it is ready.

--- a/extra/repo-install.sh
+++ b/extra/repo-install.sh
@@ -5,13 +5,13 @@
 # updated; this also include dependencies **OUTSIDE OF PYTHON**, like
 # 'opusfile-devel' on Fedora.
 # Either way, the debug message pointing out what is missing when
-# compiling PHAzOR (line #16) helps you find out what is needed.
+# compiling PHAzOR (line #34) helps you find out what is needed.
 # Those packages usually have similar enough names to be found quite
 # easily by your package manager of choice.
 #
 # The script below installs the TauonMusicBox repo as a desktop app by
 # cloning files into temporary ones and changing+deploying them;
-# lines #38 to #43. I did it because I was too lazy to learn RPM
+# lines #38 to #44. I did it because I was too lazy to learn RPM
 # packaging :B
 #
 # If you're running it for the very first time

--- a/extra/repo-uninstall.sh
+++ b/extra/repo-uninstall.sh
@@ -2,9 +2,7 @@
 #
 # Removes everything 'extra/repo-install.sh' creates.
 
-RepoDir=$(realpath $(dirname "$0")/..)
 ShareDir=~/.local/share
-cd $RepoDir
 
 set -e
 

--- a/extra/tauonmb.desktop
+++ b/extra/tauonmb.desktop
@@ -37,4 +37,4 @@ Name=Next Track
 
 [Desktop Action Stop]
 Exec=/opt/tauon-music-box/tauonmb.sh --no-start --stop
-Name=Next Track
+Name=Stop


### PR DESCRIPTION
I think this is final :)

Now the parsing only happens to `tauonmb.tmp.desktop`, making the necessary "shortcuts".

Also, small fix on the original `tauonmb.desktop` file... even though I realize now that the stop request isn't even used; line 24.