### PR TITLE
Parse metadata_block_picture blocks in Ogg

### DIFF
--- a/t_modules/t_tagscan.py
+++ b/t_modules/t_tagscan.py
@@ -23,6 +23,7 @@
 import struct
 import wave
 import io
+import base64
 import os
 import math
 from t_modules.t_extra import process_odat
@@ -102,7 +103,6 @@ class Flac:
 
         self.filepath = file
         self.has_picture = False
-        self.picture = ""
 
         self.album_artist = ""
         self.artist = ""
@@ -507,7 +507,7 @@ class Opus:
                         print("Tag Scanner: Found picture in OGG/OPUS file.")
                         print("      In file: " + self.filepath)
                         self.has_picture = True
-                        self.picture = b
+                        self.picture = parse_picture_block(io.BytesIO(base64.b64decode(b)))
                         # print(b)
 
                     elif 'replaygain_track_gain' == a:
@@ -579,7 +579,6 @@ class Ape:
 
         self.filepath = file
         self.has_picture = False
-        self.picture = ""
 
         self.found_tag = False
         self.album_artist = ""


### PR DESCRIPTION
The METADATA_BLOCK_PICTURE in an Ogg container is a base64-encoded comment containing a METADATA_BLOCK_PICTURE block identical to FLAC’s format.