### PR TITLE
Add requirement to requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,4 @@ setproctitle
 pulsectl
 mutagen
 natsort
+httpx


### PR DESCRIPTION
Installed Tauon Music Box today and I had an error saying that module httpx was not found when I tried to launch it. So I thought I'd add it to the requirements.txt here.