### PR TITLE
Fix accidental dev invocation.

### DIFF
--- a/tauon.py
+++ b/tauon.py
@@ -90,7 +90,7 @@ if install_mode:
 if not os.path.isdir(user_directory):
     os.makedirs(user_directory)
 
-if os.path.isfile('.gitignore'):
+if os.path.isfile(os.path.join(install_directory, '.gitignore')):
     print("Dev mode, ignoring single instancing")
 elif sys.platform != 'win32':
     pid_file = os.path.join(user_directory, 'program.pid')


### PR DESCRIPTION
Dev mode ignores single instancing. However, whether we launch in dev mode is based on the presence of a .gitignore file *in the current path*. This check was too simplistic and would result in accidental dev invocations.

For example, when the user has a global .gitignore file in their $HOME directory. Launchers, e.g. rofi, will use $HOME as their current directory. The simplistic check will assume the global .gitignore file to be this project's file instead.