### PR TITLE
Fix PermissionError upon exit on Windows

### DIFF
--- a/t_modules/t_phazor.py
+++ b/t_modules/t_phazor.py
@@ -29,6 +29,8 @@ import shutil
 from t_modules.t_extra import *
 import mutagen
 import hashlib
+import gi
+from gi.repository import GLib
 
 def player4(tauon):
 
@@ -274,8 +276,9 @@ def player4(tauon):
     class Cachement:
         def __init__(self):
             self.direc = audio_cache2
-            if prefs.tmp_cache and os.path.isdir("/tmp"):
-                self.direc = "/tmp/TauonMusicBox/audio-cache"
+            if prefs.tmp_cache:
+                tmp_dir = GLib.get_tmp_dir()
+                self.direc = os.path.join(tmp_dir, "TauonMusicBox", "audio-cache")
             if not os.path.exists(self.direc):
                 os.makedirs(self.direc)
             self.list = prefs.cache_list


### PR DESCRIPTION
If Tauon is closed while it is playing a song (e.g. playing from Jellyfin), then the following error message is shown:
![tauon windows error](https://user-images.githubusercontent.com/859317/219986424-6e849ccf-e20c-4995-8725-f8ddc0690ab4.jpg)

Fixing this by obtaining the proper cross-platform tmp directory.