### PR TITLE
Pause music when output device is removed

### DIFF
--- a/src/phazor/phazor.c
+++ b/src/phazor/phazor.c
@@ -887,17 +887,6 @@ void stop_decoder() {
     decoder_allocated = 0;
 }
 
-
-int disconnect_pulse() {
-    //printf("ph: Disconnect Device\n");
-
-    if (pulse_connected == 1) {
-        ma_device_uninit(&device);
-    }
-    pulse_connected = 0;
-    return 0;
-}
-
 float gate = 1.0;  // Used for ramping
 
 int get_audio(int max, float* buff){
@@ -1153,6 +1142,17 @@ void decode_seek(int abs_ms, int sample_rate) {
     }
 }
 
+int disconnect_pulse() {
+    //printf("ph: Disconnect Device\n");
+
+    if (pulse_connected == 1) {
+        ma_device_uninit(&device);
+        ma_context_uninit(&context);
+    }
+    pulse_connected = 0;
+    return 0;
+}
+
 void connect_pulse() {
 
     if (pulse_connected == 1) {
@@ -1181,6 +1181,7 @@ void connect_pulse() {
     result = ma_context_get_devices(&context, &pPlaybackDeviceInfos, &playbackDeviceCount, NULL, NULL);
     if (result != MA_SUCCESS) {
         printf("Failed to retrieve device information.\n");
+        ma_context_uninit(&context);
         return;
     }
 
@@ -1199,6 +1200,7 @@ void connect_pulse() {
 
     if (ma_device_init(&context, &config, &device) != MA_SUCCESS) {
         printf("ph: Device init error\n");
+        ma_context_uninit(&context);
         mode = STOPPED;
         return;  // Failed to initialize the device.
     }
@@ -1224,12 +1226,9 @@ void connect_pulse() {
 
     current_sample_rate = sample_rate_out;
 
-    ma_context_uninit(&context);
-
     pulse_connected = 1;
 
 }
-
 
 FILE *uni_fopen(char *ff){
     #ifdef WIN

--- a/t_modules/t_phazor.py
+++ b/t_modules/t_phazor.py
@@ -217,13 +217,18 @@ def player4(tauon):
             return 0
 
     ff_run = FFRun()
+    
+    def pause_when_device_unavailable():
+        pctl.pause_only()
+    
     FUNCTYPE = CFUNCTYPE
     if tauon.msys:
         FUNCTYPE = WINFUNCTYPE
     start_callback = FUNCTYPE(c_int, c_char_p, c_int, c_int)(ff_run.start)
     read_callback = FUNCTYPE(c_int, c_void_p, c_int)(ff_run.read)
     close_callback = FUNCTYPE(c_void_p)(ff_run.close)
-    aud.set_callbacks(start_callback, read_callback, close_callback)
+    device_unavailable_callback = FUNCTYPE(c_void_p)(pause_when_device_unavailable)
+    aud.set_callbacks(start_callback, read_callback, close_callback, device_unavailable_callback)
 
     def calc_rg(track):
 


### PR DESCRIPTION
There are 2 commits.

The first one fixes an issue with phazor where it uninit the ma_context right away.
For WASAPI backend, `ma_context_uninit__wasapi` will quit the command thread.
Without the command thread, WASAPI can't function properly when a device is removed and added again.
In this situation, the only way to get Tauon to function again is to close it completely and re-open.

The second diff pauses the music when audio device gets removed.