### PR TITLE
Dev Mode: Default to not saving state

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,4 @@ lib/
 *.DS_Store
 dist/
 *.exe
+.dev

--- a/tauon.py
+++ b/tauon.py
@@ -105,7 +105,8 @@ if install_mode:
 if not os.path.isdir(user_directory):
     os.makedirs(user_directory)
 
-if os.path.isfile(os.path.join(install_directory, '.gitignore')):
+dev_mode = os.path.isfile(os.path.join(install_directory, '.dev'))
+if dev_mode:
     print("Dev mode, ignoring single instancing")
 elif sys.platform != 'win32':
     pid_file = os.path.join(user_directory, 'program.pid')
@@ -325,6 +326,7 @@ h.n_version = n_version
 h.t_version = t_version
 h.t_id = t_id
 h.agent = t_agent
+h.dev_mode = dev_mode
 
 del raw_image
 del sdl_texture


### PR DESCRIPTION
This diff adds code to avoid saving state by default while in dev mode. It can still be enabled via the MENU if needed.

The benefit of this is that when someone is developing or debugging, perhaps repeatedly playing songs, doing that won't artificially change things.