### PR TITLE
Fix /tmp/TauonMusicBox being used on Windows

### DIFF
--- a/t_modules/t_extra.py
+++ b/t_modules/t_extra.py
@@ -32,6 +32,12 @@ import re
 import math
 import threading
 import urllib.parse
+import gi
+from gi.repository import GLib
+
+def tmp_cache_dir():
+    tmp_dir = GLib.get_tmp_dir()
+    return os.path.join(tmp_dir, "TauonMusicBox")
 
 # A seconds based timer
 class Timer:

--- a/t_modules/t_main.py
+++ b/t_modules/t_main.py
@@ -23892,7 +23892,7 @@ def transcode_single(item, manual_directroy=None, manual_name=None):
         try:
             url, params = pctl.get_url(t)
             assert url
-            path = "/tmp/TauonMusicBox/" + str(t.index)
+            path = os.path.join(tmp_cache_dir(), str(t.index))
             if os.path.exists(path):
                 os.remove(path)
             print("Downloading file...")
@@ -26660,7 +26660,7 @@ def worker1():
                 if os.path.isfile(full_target_out_p):
                     os.remove(full_target_out_p)
 
-                cache_dir = "/tmp/TauonMusicBox"
+                cache_dir = tmp_cache_dir()
                 if not os.path.isdir(cache_dir):
                     os.makedirs(cache_dir)
 
@@ -48099,9 +48099,10 @@ SDL_Quit()
 exit_timer = Timer()
 exit_timer.set()
 
-if os.path.isdir("/tmp/TauonMusicBox"):
+cache_dir = tmp_cache_dir()
+if os.path.isdir(cache_dir):
     print("Clear tmp cache")
-    shutil.rmtree("/tmp/TauonMusicBox")
+    shutil.rmtree(cache_dir)
 
 if not tauon.quick_close:
     while tm.check_playback_running() or lfm_scrobbler.running:

--- a/t_modules/t_phazor.py
+++ b/t_modules/t_phazor.py
@@ -29,8 +29,6 @@ import shutil
 from t_modules.t_extra import *
 import mutagen
 import hashlib
-import gi
-from gi.repository import GLib
 
 def player4(tauon):
 
@@ -282,8 +280,7 @@ def player4(tauon):
         def __init__(self):
             self.direc = audio_cache2
             if prefs.tmp_cache:
-                tmp_dir = GLib.get_tmp_dir()
-                self.direc = os.path.join(tmp_dir, "TauonMusicBox", "audio-cache")
+                self.direc = os.path.join(tmp_cache_dir(), "audio-cache")
             if not os.path.exists(self.direc):
                 os.makedirs(self.direc)
             self.list = prefs.cache_list


### PR DESCRIPTION
#932 fixed the location of the audio-cache dir on Windows, but I found that "/tmp/TauonMusicBox" path is still being used at several places.

Closing the app doesn't properly clean the cache dir after #932.

Fixing this by changing all instances of "/tmp/TauonMusicBox" to be cross-platform compatible.