### PR TITLE
Fix album in queue being modified causes a crash

### DIFF
--- a/t_modules/t_main.py
+++ b/t_modules/t_main.py
@@ -38446,7 +38446,7 @@ class QueueBox:
                         i = pctl.playlist_playing_position + 1
 
 
-                    elif i > len(playlist) - 1 or (playlist[i] != item[0] and item[0] in playlist):
+                    elif (i < len(playlist) and playlist[i] != item[0]) or item[0] in playlist:
                         i = playlist.index(item[0])
 
                     while i < len(playlist):


### PR DESCRIPTION
I faced a crash at startup with the following stacktrace on v7.6.3:
```
Traceback (most recent call last):
  File "tauon.py", line 340, in <module>
    from t_modules import t_main
  File "<frozen importlib._bootstrap>", line 1027, in _find_and_load
  File "<frozen importlib._bootstrap>", line 1006, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 688, in _load_unlocked
  File "PyInstaller/loader/pyimod02_importers.py", line 352, in exec_module
  File "t_modules/t_main.py", line 45633, in <module>
  File "t_modules/t_main.py", line 38447, in draw
ValueError: 1619 is not in list
```

And was able to reproduce it against the master branch, which gives similar stacktrace but with different line numbers (+3 lines shift on the last stackframe). Wrapping my head around broken state and being unable to restore the state, I dig into the code.
Looking at `QueueBox.draw` function I spotted this gem, in the code it checks for playlist modification, more specifically, a track position shift due to tracks got moved to before a target one. However, when a track got deleted, it passes the check and tries to get index with a track number that playlist actually doesn't contain, which results in `ValueError` being thrown.

My code adds up to playlist modifications, making it possible to tracks get removed, moved and etc.

What have I tested this code against, while having a playlist in queue:
- tracks get moved before a target's one position
- tracks get moved after a target's one position
- tracks get removed from the playlist

What this PR doesn't do is change queue behavior of selection when playlist gets messed with, it starts playing other track from the playlist but not next one and only god knows why it does it.