### PR TITLE
Check type of track before trying to load.

### DIFF
--- a/t_modules/t_spot.py
+++ b/t_modules/t_spot.py
@@ -770,9 +770,10 @@ class SpotCtl:
         pages = self.spotify.all_pages(p.tracks)
         for page in pages:
             for item in page.items:
-                nt = self.load_track(item.track, include_album_url=True)
-                self.tauon.pctl.master_library[nt.index] = nt
-                playlist.append(nt.index)
+                if type(item.track) == tk.model.FullPlaylistTrack:
+                    nt = self.load_track(item.track, include_album_url=True)
+                    self.tauon.pctl.master_library[nt.index] = nt
+                    playlist.append(nt.index)
 
         if return_list:
             return playlist
@@ -939,7 +940,7 @@ class SpotCtl:
     def load_track(self, track, update_master_count=True, include_album_url=False):
         if "spotify" in track.external_urls:
             pr = self.current_imports.get(track.external_urls["spotify"])
-        
+
         else:
             pr = False
 
@@ -991,7 +992,7 @@ class SpotCtl:
     def like_track(self, tract_object):
         self.connect()
         if not self.spotify:
-            return 
+            return
         track_url = tract_object.misc.get("spotify-track-url", False)
         if track_url:
             id = track_url.strip("/").split("/")[-1]


### PR DESCRIPTION
When I was trying to import all of my Spotify playlists, I ran into this error:

```
Exception in thread Thread-13 (import_all_playlists):
Traceback (most recent call last):
  File "/usr/lib/python3.11/threading.py", line 1038, in _bootstrap_inner
    self.run()
  File "/usr/lib/python3.11/threading.py", line 975, in run
    self._target(*self._args, **self._kwargs)
  File "/app/bin/t_modules/t_spot.py", line 294, in import_all_playlists
    self.playlist(item[1], silent=True)
  File "/app/bin/t_modules/t_spot.py", line 773, in playlist
    nt = self.load_track(item.track, include_album_url=True)
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/app/bin/t_modules/t_spot.py", line 961, in load_track
    if "spotify" in track.artists[0].external_urls:
                    ^^^^^^^^^^^^^
AttributeError: 'FullPlaylistEpisode' object has no attribute 'artists'
```

I noticed this happened because of playlists that contained podcast episodes. The same will happen with playlists that contain local music files. I didn't want to manually add only playlists that contained music tracks as I have way too many, so I came up with this solution.

I'm basically checking the type of the track and ensuring it is a music track before trying to load its information.

Do tell me if you'd rather implement a fancier solution. Since loading anything other than a music track currently leads to an Error, I assumed podcasts and etc. weren't meant to be supported.