### PR TITLE
Improve support for more easy packaging from Linux distros

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,19 @@
+cmake_minimum_required(VERSION 3.10)
+project(phazor)
+
+add_library(phazor SHARED src/phazor/phazor.c)
+
+find_package(PkgConfig REQUIRED)
+
+pkg_check_modules(phazor REQUIRED flac libopenmpt libmpg123 opus opusfile wavpack samplerate)
+
+find_package(kissfft CONFIG COMPONENTS float)
+if(NOT kissfft_FOUND)
+	add_subdirectory(src/phazor/kissfft)
+endif()
+
+target_include_directories(phazor PRIVATE ${phazor_INCLUDE_DIRS})
+target_link_libraries(phazor kissfft::kissfft ${phazor_LIBRARIES})
+
+
+install(TARGETS phazor DESTINATION ${CMAKE_SOURCE_DIR}/lib)

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,16 @@
+from setuptools import setup, find_packages, Extension
+
+with open('requirements.txt') as f:
+    required = f.read().splitlines()
+
+setup(
+    name = 'Tauon Music Box',
+    packages = find_packages(),
+    version = '7.7.2',
+    url = 'https://tauonmusicbox.rocks/',
+    license = 'GPL-3',
+    install_requires=required,
+	classifiers=[
+		'Programming Language :: Python :: 3'
+	],
+)

--- a/t_modules/t_main.py
+++ b/t_modules/t_main.py
@@ -141,6 +141,10 @@ except:
 # if system == "windows" or msys:
 #     os.environ["PYSDL2_DLL_PATH"] = install_directory + "\\lib"
 
+# Assume that it's a classic Linux install, use standard paths
+if install_directory.startswith("/usr/"):
+    install_directory = "/usr/share/TauonMusicBox"
+
 # Set data folders (portable mode)
 user_directory = install_directory
 config_directory = user_directory

--- a/t_modules/t_phazor.py
+++ b/t_modules/t_phazor.py
@@ -55,7 +55,12 @@ def player4(tauon):
     loaded_track = None
     fade_time = 400
 
-    aud = ctypes.cdll.LoadLibrary(pctl.install_directory + "/lib/libphazor.so")
+    if os.path.isfile(pctl.install_directory + "/lib/libphazor.so"):
+        # XXX: May be unnecesary. It's only to ensure compatibility with WWindows
+        aud = ctypes.cdll.LoadLibrary(pctl.install_directory + "/lib/libphazor.so")
+    else:
+        aud = ctypes.cdll.LoadLibrary("libphazor.so")
+
     aud.init()
 
     aud.get_device.restype = ctypes.c_char_p

--- a/tauon.py
+++ b/tauon.py
@@ -78,11 +78,6 @@ if pyinstaller_mode:
      os.environ["PATH"] += ":" + sys._MEIPASS
      os.environ['SSL_CERT_FILE'] = os.path.join(install_directory, "certifi", "cacert.pem")
 
-user_directory = os.path.join(install_directory, "user-data")
-config_directory = user_directory
-
-asset_directory = os.path.join(install_directory, "assets")
-
 # If we're installed, use home data locations
 install_mode = False
 if install_directory.startswith("/opt/")\
@@ -90,6 +85,14 @@ if install_directory.startswith("/opt/")\
         or install_directory.startswith("/app/")\
         or install_directory.startswith("/snap/") or sys.platform == "darwin" or sys.platform == 'win32':
     install_mode = True
+
+# Assume that it's a classic Linux install, use standard paths
+if install_directory.startswith("/usr/"):
+    install_directory = "/usr/share/TauonMusicBox"
+
+user_directory = os.path.join(install_directory, "user-data")
+config_directory = user_directory
+asset_directory = os.path.join(install_directory, "assets")
 
 if install_directory.startswith("/app/"):
     # Its Flatpak
@@ -345,7 +348,7 @@ del rect
 del flags
 del img_path
 
-if pyinstaller_mode or sys.platform == "darwin":
+if pyinstaller_mode or sys.platform == "darwin" or install_mode:
     from t_modules import t_main
 else:
     # Using the above import method breaks previous pickles. Could be fixed


### PR DESCRIPTION
Closes: #828

- added a CMakeLists.txt to build phrazor component. 
- added a setup.py to build the t_module python module to be able to be installed with the standard approaches of different Linux distros.
- modified install_directory when the program is installed under /usr so it seeks assets in the standard /usr/share directory