### PR TITLE
Fixes two issues for reading single channel files

### DIFF
--- a/src/phazor/phazor.c
+++ b/src/phazor/phazor.c
@@ -1281,6 +1281,7 @@ int load_next() {
     long rate;
     int e = 0;
     int old_sample_rate = sample_rate_src;
+    src_channels = 2;
 
     char *ext;
     ext = strrchr(loaded_target_file, '.');
@@ -1852,7 +1853,12 @@ void pump_decode() {
 
         unsigned int done;
 
-        done = op_read_stereo(opus_dec, opus_buffer, 1024 * 2) * 2;
+        if(src_channels == 1){
+          done = op_read(opus_dec, opus_buffer, 4096, NULL);
+        }
+        else{
+          done = op_read_stereo(opus_dec, opus_buffer, 1024 * 2) * 2;
+        }
 
         pthread_mutex_lock(&buffer_mutex);
         read_to_buffer_s16int(opus_buffer, done);


### PR DESCRIPTION
Playing single channel opus files results in incorrect audio output.
Playing a wav file after playing a single channel opus file also produces incorrect output, but after playing a two channel file (any) then playing the wav again the audio is fine. 
These changes should fix the two issues. 