### PR TITLE
Type up parts of webserver and main

### DIFF
--- a/src/tauon/t_modules/t_dbus.py
+++ b/src/tauon/t_modules/t_dbus.py
@@ -41,7 +41,6 @@ if TYPE_CHECKING:
 class Gnome:
 
 	def __init__(self, tauon: Tauon) -> None:
-
 		self.bus_object = None
 		self.tauon = tauon
 		self.indicator_launched = False
@@ -50,11 +49,9 @@ class Gnome:
 		self.tray_text = ""
 		self.resume_playback = False
 
-
 		tauon.set_tray_icons()
 
 	def focus(self) -> None:
-
 		if self.bus_object is not None:
 			try:
 				# this is what gives us the multi media keys.
@@ -90,7 +87,6 @@ class Gnome:
 			self.indicator.set_icon_full(self.tauon.get_tray_icon("tray-indicator-default"), "default")
 
 	def start_indicator(self) -> None:
-
 		pctl = self.tauon.pctl
 		tauon = self.tauon
 
@@ -234,7 +230,6 @@ class Gnome:
 		self.tauon.gui.update += 1
 
 	def main(self) -> None:
-
 		import dbus
 		import dbus.mainloop.glib
 		import dbus.service
@@ -248,7 +243,6 @@ class Gnome:
 			self.show_indicator()
 
 		def on_mediakey(comes_from: str, what: str) -> None:
-
 			if what == "Play":
 				self.tauon.inp.media_key = "Play"
 			elif what == "Pause":
@@ -301,7 +295,6 @@ class Gnome:
 			tauon.update_play_lock = update_play_lock
 
 			def PrepareForSleep(active: int) -> None:
-
 				if active == 1 and tauon.sleep_lock is not None:
 					logging.info("System is suspending!")
 					if pctl.playing_state == 3 and not tauon.spot_ctl.coasting:

--- a/src/tauon/t_modules/t_main.py
+++ b/src/tauon/t_modules/t_main.py
@@ -272,6 +272,7 @@ if TYPE_CHECKING:
 	from subprocess import Popen
 	from pylast import LastFMNetwork
 	from collections.abc import Callable
+	from tauon.t_modules.t_webserve import ThreadedHTTPServer
 
 # Detect platform
 macos = False
@@ -1279,8 +1280,6 @@ class ColoursClass:
 		self.top_panel_background = self.grey(15)
 		self.status_text_over: ColourRGBA | None = None
 		self.status_text_normal: ColourRGBA | None = None
-
-
 
 
 		self.side_panel_background = self.grey(18)
@@ -5900,7 +5899,7 @@ class Tauon:
 		self.chunker                              = Chunker()
 		self.stream_proxy                         = StreamEnc(self)
 		self.level_train:       list[list[float]] = []
-		self.radio_server                         = None
+		self.radio_server: ThreadedHTTPServer | None = None
 		self.listen_alongers:    dict[str, Timer] = {}
 		self.encode_folder_name                   = encode_folder_name
 		self.encode_track_name                    = encode_track_name
@@ -5912,10 +5911,10 @@ class Tauon:
 		self.tray_releases = 0
 
 		self.play_lock = None
-		self.update_play_lock = None
+		self.update_play_lock: Callable[[], None] | None = None
 		self.sleep_lock = None
 		self.shutdown_lock = None
-		self.quick_close = False
+		self.quick_close: bool = False
 		self.pl_to_id = self.pctl.pl_to_id
 		self.id_to_pl = self.pctl.id_to_pl
 
@@ -5930,10 +5929,10 @@ class Tauon:
 
 		#self.recorded_songs = []
 
-		self.chrome_mode = False
-		self.web_running = False
+		self.chrome_mode: bool = False
+		self.web_running: bool = False
 		self.web_thread = None
-		self.remote_limited = True
+		self.remote_limited: bool = True
 		self.enable_librespot = shutil.which("librespot")
 
 		self.MenuItem = MenuItem
@@ -14542,7 +14541,7 @@ class Tauon:
 	def start_remote(self) -> None:
 		if not self.web_running:
 			self.web_thread = threading.Thread(
-				target=webserve2, args=[self.pctl, self.prefs, self.gui, self.album_art_gen, str(self.install_directory), self.strings, self])
+				target=webserve2, args=[self.pctl, self.album_art_gen, self])
 			self.web_thread.daemon = True
 			self.web_thread.start()
 			self.web_running = True
@@ -31147,8 +31146,8 @@ class RadioBox:
 	def start2(self, url: str) -> None:
 		if self.run_proxy and not self.tauon.stream_proxy.start_download(url):
 			self.load_failed_timer.set()
-			self.load_failed = True
-			self.load_connecting = False
+			self.load_failed: bool = True
+			self.load_connecting: bool = False
 			self.gui.update += 1
 			logging.error("Starting radio failed")
 			# self.show_message(_("Failed to establish a connection"), mode="error")
@@ -31156,9 +31155,9 @@ class RadioBox:
 
 		self.loaded_url = url
 		self.pctl.playing_state = 0
-		self.pctl.record_stream = False
+		self.pctl.record_stream: bool = False
 		self.pctl.playerCommand = "url"
-		self.pctl.playerCommandReady = True
+		self.pctl.playerCommandReady: bool = True
 		self.pctl.playing_state = 3
 		self.pctl.playing_time = 0
 		self.pctl.decode_time = 0
@@ -31170,8 +31169,8 @@ class RadioBox:
 			self.tauon.update_play_lock()
 
 		time.sleep(0.1)
-		self.load_connecting = False
-		self.load_failed = False
+		self.load_connecting: bool = False
+		self.load_failed: bool = False
 		self.gui.update += 1
 
 		wss = ""

--- a/src/tauon/t_modules/t_webserve.py
+++ b/src/tauon/t_modules/t_webserve.py
@@ -36,6 +36,8 @@ from tauon.t_modules.t_extra import Timer
 if TYPE_CHECKING:
 	from tauon.t_modules.t_main import AlbumArt, GuiVar, PlayerCtl, Prefs, Strings, Tauon, TrackClass
 
+class ThreadedHTTPServer(ThreadingMixIn, HTTPServer):
+	pass
 
 def send_file(path: str, mime: str, server) -> None:
 	range_req = False
@@ -83,7 +85,6 @@ def webserve(pctl: PlayerCtl, prefs: Prefs, gui: GuiVar, album_art_gen: AlbumArt
 	gui.web_running = True
 
 	class Server(BaseHTTPRequestHandler):
-
 		def log_message(self, format, *args) -> None:
 			logging.info(format % args)
 
@@ -214,9 +215,6 @@ def webserve(pctl: PlayerCtl, prefs: Prefs, gui: GuiVar, album_art_gen: AlbumArt
 				self.end_headers()
 				self.wfile.write(b"404 Not found")
 
-	class ThreadedHTTPServer(ThreadingMixIn, HTTPServer):
-		pass
-
 	try:
 		httpd = ThreadedHTTPServer(("0.0.0.0", prefs.metadata_page_port), Server)
 		tauon.radio_server = httpd
@@ -231,8 +229,7 @@ def webserve(pctl: PlayerCtl, prefs: Prefs, gui: GuiVar, album_art_gen: AlbumArt
 		logging.exception("Failed starting radio page server!")
 
 
-def webserve2(pctl: PlayerCtl, prefs: Prefs, gui: GuiVar, album_art_gen: AlbumArt, install_directory: str, strings: Strings, tauon: Tauon) -> None:
-
+def webserve2(pctl: PlayerCtl, album_art_gen: AlbumArt, tauon: Tauon) -> None:
 	play_timer = Timer()
 
 	class Server(BaseHTTPRequestHandler):
@@ -675,9 +672,6 @@ def webserve2(pctl: PlayerCtl, prefs: Prefs, gui: GuiVar, album_art_gen: AlbumAr
 				self.end_headers()
 				self.wfile.write(b"404 Not found")
 			tauon.wake()
-
-	class ThreadedHTTPServer(ThreadingMixIn, HTTPServer):
-		pass
 
 	try:
 		httpd = ThreadedHTTPServer(("0.0.0.0", 7814), Server)


### PR DESCRIPTION
Dedupes the `ThreadedHTTPServer` definition and moves it out of the function to allow it be imported from main.

Removes unneeded args for webserve2 - Tauon has them within anyways now.

Small typing changes.