### PR TITLE
Fix Jellyfin playlist import

### DIFF
--- a/src/tauon/t_modules/t_jellyfin.py
+++ b/src/tauon/t_modules/t_jellyfin.py
@@ -409,7 +409,7 @@ class Jellyfin:
 					"userId": self.userId,
 					"fields": ["Genres", "DateCreated", "MediaSources", "People"],
 					"enableImages": False,
-					"mediaTypes": ["Audio"],
+					"includeItemTypes": ["Audio", "Playlist"],
 					"recursive": True,
 				},
 				# Someone had a local setup with 36k songs where sync took 31s,


### PR DESCRIPTION
Jellyfin supports importing playlists from the filesystem. Playlists that are
imported from the filesystem (e.g. "m3u" files) do not have the "Audio" media
type. Thus, change the request to query for "Audio" and "Playlist" item types
instead.

This shouldn't break any existing behavior, since these item types are filtered
for right after anyway.