### PR TITLE
Fix near-duplicate albums being incorrectly combined in most cases

### DIFF
--- a/src/tauon/t_modules/t_main.py
+++ b/src/tauon/t_modules/t_main.py
@@ -17216,13 +17216,16 @@ class Tauon:
 				current_folder = tr.parent_folder_path
 				current_album = tr.album
 				current_date = track_date
+				current_artist = tr.album_artist
 			elif tr.parent_folder_path != current_folder:
 				if tr.album == current_album and tr.album and track_date == current_date and tr.disc_number \
+						and tr.album_artist == current_artist \
 						and os.path.dirname(tr.parent_folder_path) == os.path.dirname(current_folder):
 					continue
 				current_folder = tr.parent_folder_path
 				current_album = tr.album
-				current_date = tr.date
+				current_date = track_date
+				current_artist = tr.album_artist
 				albums.append(i)
 
 		i = 0


### PR DESCRIPTION
resolves #1812, #1300 and probably #1071, but NOT #1678.

Sorting system now matches the straight up "date" field if it exists, rather than the "original release date" (this bug mostly applied to rereleases and the original release date would be identical with a rerelease). I also added album artist as a necessary matching field to resolve #1071 but obviously it only works if the files are tagged right. 