### PR TITLE
don't display album date twice if they're the same date

### DIFF
--- a/src/tauon/t_modules/t_extra.py
+++ b/src/tauon/t_modules/t_extra.py
@@ -1096,13 +1096,13 @@ def shooter(func: Callable[..., None], args: tuple = ()) -> None:
 
 
 def d_date_display(track: TrackClass) -> str:
-	if "rdat" in track.misc:
+	if "rdat" in track.misc and str(track.date) != track.misc["rdat"]:
 		return str(track.date) + " → " + track.misc["rdat"]
 	return str(track.date)
 
 
 def d_date_display2(track: TrackClass) -> str:
-	if "rdat" in track.misc:
+	if "rdat" in track.misc and str(get_year_from_string(track.date)) != get_year_from_string(track.misc["rdat"]):
 		return str(get_year_from_string(track.date)) + " → " + get_year_from_string(track.misc["rdat"])
 	return str(get_year_from_string(track.date))
 


### PR DESCRIPTION
fixes an issue where some albums would be displayed with the original release date -> rerelease date format even though the two dates were the same