### PR TITLE
ci: Attach artifacts when creating a new Release

### DIFF
--- a/.github/workflows/attach_release_files.yaml
+++ b/.github/workflows/attach_release_files.yaml
@@ -1,0 +1,40 @@
+name: attach-to-release
+on:
+  release:
+    types: [published]
+
+jobs:
+  attach:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write   # upload to release
+      actions: read     # read artifacts via API
+    steps:
+      - name: DL repo for getting tags
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+      - name: Get commit SHA for release tag
+        id: get_sha
+        run: |
+          # Fetch tags to ensure they're available
+          git fetch --tags
+
+          # Get commit hash for the tag that triggered this release
+          TAG_NAME="${{ github.event.release.tag_name }}"
+          COMMIT_SHA=$(git rev-list -n 1 "$TAG_NAME")
+
+          echo "Commit SHA for $TAG_NAME is $COMMIT_SHA"
+          echo "sha=$COMMIT_SHA" >> $GITHUB_OUTPUT
+      - name: Download artifacts from CI run for this commit/tag
+        uses: dawidd6/action-download-artifact@v11
+        with:
+          repo: ${{ github.repository }}
+          workflow: build_and_release.yaml
+          commit: ${{ steps.get_sha.outputs.sha }}
+          path: dist
+          if_no_artifact_found: fail
+      - name: Upload files to this release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: dist/**

--- a/.github/workflows/build_and_release.yaml
+++ b/.github/workflows/build_and_release.yaml
@@ -98,7 +98,7 @@ jobs:
           APP_NAME="TauonMusicBox"
           cd "dist/${APP_NAME}"
 
-          ARCHIVE_PATH="../../${APP_NAME}.7z"
+          ARCHIVE_PATH="../../${APP_NAME}-linux.7z"
 
           7z a -r "${ARCHIVE_PATH}" "."
 
@@ -106,7 +106,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: TauonMusicBox-linux
-          path: TauonMusicBox.7z
+          path: TauonMusicBox-linux.7z
 
       #- name: Run Tauon for testing
       #  run: |
@@ -418,7 +418,7 @@ jobs:
           APP_NAME="TauonMusicBox"
           cd "dist/${APP_NAME}"
 
-          ARCHIVE_PATH="../../${APP_NAME}.7z"
+          ARCHIVE_PATH="../../${APP_NAME}-windows.7z"
 
           7z a -r "${ARCHIVE_PATH}" "."
 
@@ -430,7 +430,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: TauonMusicBox-windows
-          path: TauonMusicBox.7z
+          path: TauonMusicBox-windows.7z
 
       - name: Replace Tauon version in .ISS
         run: |


### PR DESCRIPTION
Fixes #1884

One needs to watch out to only publish a release after the builds have succeeded, otherwise it'll need to later be re-ran from Actions.

The workflow is to create a new Release as a draft (which creates a tag), wait for the newly-started-CI to finish running in about 15 minutes, and only then release.

This will attach all the artifacts to the release, with no manual labor involved.

One small "issue" is that the Flatpak asset is uploaded too, which is easy to remove if undesired.

<img width="855" height="872" alt="image" src="https://github.com/user-attachments/assets/f4feb27e-2b9a-42c9-9183-6a6e1c5866e9" />
