### PR TITLE
Rename menu item 'Reload All Folders' to 'Rescan All Folders'

### DIFF
--- a/src/tauon/t_modules/t_main.py
+++ b/src/tauon/t_modules/t_main.py
@@ -43923,7 +43923,7 @@ def main(holder: Holder) -> None:
 	# x_menu.add('Toggle Side panel', tauon.toggle_combo_view, tauon.combo_deco)
 
 	x_menu.add_to_sub(0, MenuItem(_("Export as CSV"), tauon.export_database))
-	x_menu.add_to_sub(0, MenuItem(_("Reload All Folders"), pctl.rescan_all_folders))
+	x_menu.add_to_sub(0, MenuItem(_("Rescan All Folders"), pctl.rescan_all_folders))
 	x_menu.add_to_sub(0, MenuItem(_("Play History to Playlist"), tauon.q_to_playlist))
 	x_menu.add_to_sub(0, MenuItem(_("Reset Image Cache"), tauon.clear_img_cache))
 


### PR DESCRIPTION
This PR makes a very small UI text correction:
“Reload All Folders” → “Rescan All Folders”

The main module `t_main.py` has a different string from `messages.pot`...

`t_main.py`
<img width="597" height="40" alt="Captura de tela de 2025-12-01 02-14-19" src="https://github.com/user-attachments/assets/e132924e-9790-4ee0-a53f-babe0472ef83" />

`messages.pot`
<img width="308" height="152" alt="Captura de tela de 2025-12-01 02-07-08" src="https://github.com/user-attachments/assets/5a8356ca-718e-4e97-948d-050f64c66522" />

resulting in a bug to translations
<img width="435" height="245" alt="Captura de tela de 2025-12-01 02-08-36" src="https://github.com/user-attachments/assets/1d723923-32eb-4fbd-991d-65cfdbd63645" /> (pt-br example)

No logic or UI structure was modified, only the display text.