### PR TITLE
Improve packaging

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@
 	version = "8.2.2"
 	description = "Tauon Music Box is a music player"
 	readme = "README.md"
-	license = { text = "GPL-3.0-or-later" }
+	license = "GPL-3.0-or-later"
 	# Change the version for the tools below too when bumping up
 	requires-python = ">=3.10"
 	classifiers = [
@@ -66,7 +66,7 @@
 	homepage = "https://tauonmusicbox.rocks/"
 
 [build-system]
-	requires = ["setuptools>=75.3", "setuptools_scm"]
+	requires = ["setuptools>=75.3"]
 	build-backend = "setuptools.build_meta"
 
 [tool.setuptools]

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,32 @@
+import sys
+from pathlib import Path
+
+from setuptools import setup
+from setuptools.command.build import build as _build
+from setuptools.command.sdist import sdist as _sdist
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from compile_translations import main as compile_translations
+
+
+class BuildWithTranslations(_build):
+	"""Run compile_translations before standard build."""
+
+	def run(self) -> None:
+		compile_translations()
+		super().run()
+
+
+class SdistWithTranslations(_sdist):
+	"""Ensure translations are compiled in sdist tarball."""
+
+	def run(self) -> None:
+		compile_translations()
+		super().run()
+
+_ = setup(
+	cmdclass={
+		"build": BuildWithTranslations,
+		"sdist": SdistWithTranslations,
+	},
+)


### PR DESCRIPTION
This gets rid of scm warnings.

This gets rid of license warnings.

This makes sure to compile the translations during build, therefore it is no longer possible to build Tauon without translations.

This fixes Nix packaging and possibly other places, and removes the need to call compile_translations.py manually.