### PR TITLE
Warn when encountering non-standard FMPS tag

### DIFF
--- a/src/tauon/t_modules/t_main.py
+++ b/src/tauon/t_modules/t_main.py
@@ -11420,11 +11420,15 @@ class Tauon:
 		self.thread_manager.ready("worker")
 
 	def import_fmps(self) -> None:
+		"""FMPS spec: https://gitorious.org/xdg-specs/xdg-specs/trees/master/specifications/FMPSpecs?p=xdg-specs:xdg-specs.git;a=blob;f=specifications/FMPSpecs/specification.txt;hb=HEAD#l235"""
 		unique = set()
 		for playlist in self.pctl.multi_playlist:
 			for id in playlist.playlist_ids:
 				tr = self.pctl.get_track(id)
 				if "FMPS_Rating" in tr.misc:
+					if tr.misc["FMPS_Rating"] > 1 or tr.misc["FMPS_Rating"] < 0:
+						logging.warning(f"Nonstandard FMPS_RATING in track, skipping {tr.fullpath}: {tr.misc['FMPS_Rating']}")
+						continue
 					rating = round(tr.misc["FMPS_Rating"] * 10)
 					self.star_store.set_rating(tr.index, rating)
 					unique.add(tr.index)


### PR DESCRIPTION
We've had an user convert from another player by writing AI-assisted code which used non-standard values for the ratings, check this on our side so we don't save a value like "600" to a rating field that's' supposed to be from 0 to 10.