### PR TITLE
Fix parent_playlist_id type

### DIFF
--- a/src/tauon/t_modules/t_extra.py
+++ b/src/tauon/t_modules/t_extra.py
@@ -137,7 +137,7 @@ class TauonPlaylist:
 		7 last_folder import path (string)
 		8 hidden (bool)
 		9 locked (bool)
-		10 parent_playlist_id <- Filter (string)
+		10 parent_playlist_id <- Filter (int)
 		11 persist_time_positioning
 	"""
 
@@ -153,7 +153,7 @@ class TauonPlaylist:
 	]  # last folder import path (string) - TODO(Martin): BUG - we are using this both as string and list of strings in various parts of code
 	hidden: bool
 	locked: bool
-	parent_playlist_id: str  # Filter parent playlist id (string)
+	parent_playlist_id: int  # Filter parent playlist id
 	persist_time_positioning: bool  # Persist time positioning
 	playlist_file: str = ""  # Playlist may be automatically loaded to and from this filepath
 	auto_export: bool = False

--- a/src/tauon/t_modules/t_main.py
+++ b/src/tauon/t_modules/t_main.py
@@ -12307,7 +12307,7 @@ class Tauon:
 				new = self.pctl.id_to_pl(self.pctl.multi_playlist[source_pl].parent_playlist_id)
 				if new is None:
 					# The original playlist is now gone
-					self.pctl.multi_playlist[source_pl].parent_playlist_id = ""
+					self.pctl.multi_playlist[source_pl].parent_playlist_id = 0
 				else:
 					source_pl = new
 					# replace = True
@@ -14408,7 +14408,7 @@ class Tauon:
 		position:     int = 0,
 		hide_title:   bool = False,
 		selected:     int = 0,
-		parent:       str = "",
+		parent:       int = 0,
 		hidden:       bool = False,
 		notify:       bool = True, # Allows us to generate initial playlist before worker thread is ready
 		playlist_file:str = "",
@@ -33688,7 +33688,7 @@ class ArtistList:
 			# test if parent still exists
 			new = self.pctl.id_to_pl(self.pctl.multi_playlist[self.pctl.active_playlist_viewing].parent_playlist_id)
 			if new is None or not self.pctl.multi_playlist[self.pctl.active_playlist_viewing].title.startswith("Artist:"):
-				self.pctl.multi_playlist[self.pctl.active_playlist_viewing].parent_playlist_id = ""
+				self.pctl.multi_playlist[self.pctl.active_playlist_viewing].parent_playlist_id = 0
 			else:
 				viewing_pl_id = self.pctl.multi_playlist[self.pctl.active_playlist_viewing].parent_playlist_id
 


### PR DESCRIPTION
We were creating it as string, and sometimes setting it as string to zero it out, but using it as int in the code (which seems to work fine due to how the code is written as it gets overwritten by an int before being used?).

Fix it and use it as int everywhere.