### PR TITLE
fix: Optimize SDL Poll event code

### DIFF
--- a/src/tauon/t_modules/t_main.py
+++ b/src/tauon/t_modules/t_main.py
@@ -45087,6 +45087,9 @@ def main(holder: Holder) -> None:
 			elif event.type == sdl3.SDL_EVENT_GAMEPAD_AXIS_MOTION:
 				if not prefs.use_gamepad:
 					continue
+				# Deadzone guard to prevent frequent gui refreshes
+				if abs(event.gaxis.value) <= 5000:
+					continue
 				if event.gaxis.axis == sdl3.SDL_GAMEPAD_AXIS_LEFT_TRIGGER:
 					rt = event.gaxis.value > 5000
 				if event.gaxis.axis == sdl3.SDL_GAMEPAD_AXIS_LEFTY:


### PR DESCRIPTION
Attempted to improve #1689, it helps with jumping out early and not wasting CPU cycles by fixing the ifs.

I have also added code to ignore axis events beyond a certain threshold, as the analogue movement can spam very frequently with miniscule movement and we update the GUI for each call there otherwise.