### PR TITLE
Exclude OpenSSL and cryptography modules from Linux

### DIFF
--- a/linux.spec
+++ b/linux.spec
@@ -44,7 +44,10 @@ a = Analysis(
 	hookspath=["extra/pyinstaller-hooks"],
 	hooksconfig={},
 	runtime_hooks=[],
-	excludes=[],
+	excludes=[
+		'OpenSSL',
+		'cryptography',
+	],
 	noarchive=False,
 	optimize=0,
 )


### PR DESCRIPTION
Should prevent crashes when system OpenSSL is newer than the bundled one