### PR TITLE
Correctly handle multi artists when scrobbling

### DIFF
--- a/src/tauon/t_modules/t_extra.py
+++ b/src/tauon/t_modules/t_extra.py
@@ -973,7 +973,9 @@ def filename_to_metadata(filename: str) -> tuple[str, str]:
 
 def get_artist_strip_feat(track_object: TrackClass) -> str:
 	artist_name = track_object.artist  # .lower()
-	if track_object.album_artist:
+	if track_object.misc.get("artists"):
+		artist_name = track_object.misc["artists"][0]
+	elif track_object.album_artist:
 		if (
 			"feat." in artist_name
 			or "pres." in artist_name


### PR DESCRIPTION
Because last.fm doesn't support multi artists, we just need the first artist just like what Spotify did.

How tauon handle it currently is to look for words (`;`, `ft. `, `feat. `, etc.) and if it finds one, it would use the album artist instead.
But if the album artist is `Various Artists`, tauon will send the raw string, e.g. `iroha(sasaki); 初音ミク` to scrobble server (last.fm and listenbrainz) and that would be problematic **only** for last.fm (should i let it send the whole `ARTIST(S)` to listenbrainz since it does support it?)

This of course, also has another drawback other than the `Various Artists` problem.
If we have something like
<img width="296" height="172" alt="image" src="https://github.com/user-attachments/assets/d79c1da9-911a-4064-a346-04bbc14a8781" />
(in this case the whole album is a compilation by 可不)
It would get submitted as if the artist is 可不 and not ツミキ.

My fix is to get the plural `ARTISTS` tag (or singular `ARTIST` tag with multi-value/`; ` delimiter since tauon treat them the same) first and try to submit the first artist in the list instead of relying on album artist.

Fixes #1400 