### PR TITLE
feat(discord): display artist name as status

### DIFF
--- a/src/tauon/t_modules/t_main.py
+++ b/src/tauon/t_modules/t_main.py
@@ -248,7 +248,7 @@ else:
 # except Exception:
 # 	logging.exception("Unable to import rpc, Discord Rich Presence will be disabled.")
 try:
-	from pypresence import ActivityType, Presence
+	from pypresence import ActivityType, StatusDisplayType, Presence
 except ModuleNotFoundError:
 	logging.warning("Unable to import pypresence, Discord Rich Presence will be disabled.")
 except Exception:
@@ -12140,6 +12140,7 @@ class Tauon:
 						small_image = "tauon-standard"
 					RPC.update(
 						activity_type = ActivityType.LISTENING,
+						status_display_type = StatusDisplayType.STATE,
 						pid=self.pid,
 						**({"state": artist} if self.pctl.playing_state != PlayingState.URL_STREAM else {"state": album}),
 						details=title,


### PR DESCRIPTION
Display artist name as user status, matching other RPCs that uses the same `Listening` type (e.g. Spotify)

<img width="283" height="125" alt="image" src="https://github.com/user-attachments/assets/ec60fbf5-a61a-46b5-9b54-9b9a032ece78" />
<img width="145" height="49" alt="image" src="https://github.com/user-attachments/assets/0658e498-2397-412d-adc5-bcb690cf5872" />
