### PR TITLE
Show year for partial `originaldate`

### DIFF
--- a/src/tauon/t_modules/t_extra.py
+++ b/src/tauon/t_modules/t_extra.py
@@ -242,8 +242,10 @@ class FunctionStore:
 
 j_chars = "あおいえうんわらまやはなたさかみりひにちしきるゆむぬつすくれめへねてせけをろもほのとそこアイウエオンヲラマハナタサカミヒニチシキルユムフヌツスクレメヘネテセケロヨモホノトソコ"
 year_search = re.compile(r"\d{4}")
-# Pre-compile the regular expression pattern for dates starting with the year
+# Pre-compile the regular expression pattern for dates like YYYY-MM-DD or DD-MM-YYYY
 date_pattern = re.compile(r"\b(?:\d{2}([/. -])\d{2}\1(\d{4})|\b(\d{4})([/. -])\d{2}\4\d{2}).*")
+# YYYY or YYYY-MM
+year_month_pattern = re.compile(r"^(\d{4})$|^(\d{4})([/. -])\d{2}$")
 
 genre_corrections = [
 	"J-Pop",
@@ -797,7 +799,11 @@ def get_year_from_string(s: str) -> str:
 
 	# Extract and return the year if a match is found
 	if match:
-		return match.group(2) if match.group(2) else match.group(3)
+		return match.group(2) or match.group(3)
+
+	match2 = year_month_pattern.search(s)
+	if match2:
+		return match2.group(1) or match2.group(2)
 
 	return ""
 

--- a/src/tauon/tests/test_get_year_from_string.py
+++ b/src/tauon/tests/test_get_year_from_string.py
@@ -1,0 +1,12 @@
+from tauon.t_modules import t_extra
+
+
+def test_get_year_from_string() -> None:
+	year = t_extra.get_year_from_string("2024-01-01")
+	assert year == "2024"
+
+	year = t_extra.get_year_from_string("2025-01")
+	assert year == "2025"
+
+	year = t_extra.get_year_from_string("2026")
+	assert year == "2026"


### PR DESCRIPTION
MusicBrainz can send a partial date like YYYY or YYYY-MM, not just YYYY-MM-DD like the docs say, issue was raised at https://tickets.metabrainz.org/projects/PICARD/issues/PICARD-3207

This fixes an issue where the date is not parsed at all:

<img width="304" height="211" alt="image" src="https://github.com/user-attachments/assets/1cb74410-9925-4852-9aed-7fc41cb5976d" />

I was a bit afraid to touch the original regex, so I added a second one for the partials, but I can rework it and merge it into one, if it's desired.