### PR TITLE
libprojectm fixes

### DIFF
--- a/src/tauon/t_modules/t_main.py
+++ b/src/tauon/t_modules/t_main.py
@@ -36329,10 +36329,10 @@ class ProjectM:
 			if self.lib:
 				logging.info(f"Successfully loaded: {lib_name}")
 			else:
-				logging.warning("Could not find libprojectM-4")
+				logging.warning("Could not load libprojectM-4")
 				self.lib_error = True
 		except OSError:
-			logging.warning("Could not find libprojectM-4")
+			logging.exception("Could not load libprojectM-4")
 			self.lib_error = True
 		except Exception:
 			logging.exception("Unkown error loading libprojectM-4")


### PR DESCRIPTION
Change the wording to be more correct and at the same time differentiate it from other logs that are currently identical, making it hard to debug.

Also post full exception info on OSError, as it can have useful data like which function failed to load.

Helps debug #2043