### PR TITLE
fix(config): correct typo in locale comment (zh_CH -> zh_CN)

### DIFF
--- a/src/tauon/t_modules/t_main.py
+++ b/src/tauon/t_modules/t_main.py
@@ -40333,7 +40333,7 @@ def load_prefs(bag: Bag) -> None:
 	cf.add_text("[locale]")
 	prefs.ui_lang = cf.sync_add(
 		"string", "display-language", prefs.ui_lang, "Override display language to use if "
-		"available. E.g. \"en\", \"ja\", \"zh_CH\". "
+		"available. E.g. \"en\", \"ja\", \"zh_CN\". "
 		"Default: \"auto\"")
 	# prefs.diacritic_search = cf.sync_add("bool", "decode-search", prefs.diacritic_search, "Allow searching of diacritics etc using ascii in search functions. (Disablng may speed up search)")
 	cf.br()


### PR DESCRIPTION
This PR fixes a typo in the configuration template where the ISO code for Simplified Chinese was incorrectly listed as zh_CH. The correct code is zh_CN.

Why?
New users following the comment in the generated Tauon.conf would be misled, causing the Chinese interface to fail to load.

Changes
Modified src/tauon/t_modules/t_main.py to update the example string.

Verification
Manually verified that zh_CN correctly enables the Simplified Chinese UI.