### PR TITLE
improve launcher script

### DIFF
--- a/extra/tauonmb.sh
+++ b/extra/tauonmb.sh
@@ -1,13 +1,12 @@
-#!/bin/bash
-if [ "$1" == "--no-start" ]; then
-	if [ "$2" == "--play" ];         then curl http://localhost:7813/play/
-	elif [ "$2" == "--play-pause" ]; then curl http://localhost:7813/playpause/
-	elif [ "$2" == "--pause" ];      then curl http://localhost:7813/pause/
-	elif [ "$2" == "--stop" ];       then curl http://localhost:7813/stop/
-	elif [ "$2" == "--next" ];       then curl http://localhost:7813/next/
-	elif [ "$2" == "--previous" ];   then curl http://localhost:7813/previous/
-	else tauonmb "$@";
-	fi
-else
-	tauonmb "$@"
+#!/bin/sh
+if [ "$1" = '--no-start' ]; then
+	case "$2" in
+		--play)       exec curl http://localhost:7813/play/;;
+		--play-pause) exec curl http://localhost:7813/playpause/;;
+		--pause)      exec curl http://localhost:7813/pause/;;
+		--stopcurl)   exec curl http://localhost:7813/stop/;;
+		--next)       exec curl http://localhost:7813/next/;;
+		--previous)   exec curl http://localhost:7813/previous/;;
+	esac
 fi
+exec tauonmb "$@"


### PR DESCRIPTION
The script is now POSIX and easier to read. 

Btw there is something odd, in the original script if `--no-start` is passed but `$2` does not match any `curl` action, the script passes the entire array with `$1` to `tauonmb`, is that intended? I preserved that behaviour here as well.

