### PR TITLE
add originalyear to tagscan

### DIFF
--- a/src/tauon/t_modules/t_tagscan.py
+++ b/src/tauon/t_modules/t_tagscan.py
@@ -262,6 +262,9 @@ class Flac(TrackFile):
 						self.date = b.decode("utf-8")
 					elif a == "originaldate":
 						odat = b.decode("utf-8")
+					elif a == "originalyear":
+						if odat == "":
+							odat = b.decode("utf-8")
 					elif a == "comment":
 						self.comment = b.decode("utf-8")
 					elif a == "album":
@@ -543,6 +546,9 @@ class Opus(TrackFile):
 						self.date = b.decode("utf-8")
 					elif a == "originaldate":
 						odat = b.decode("utf-8")
+					elif a == "originalyear":
+						if odat == "":
+							odat = b.decode("utf-8")
 					elif a == "comment":
 						self.comment = b.decode("utf-8")
 					elif a == "album":


### PR DESCRIPTION
As mentioned in #2041. It's nice to have because some files only have the year.
This adds support for the originalyear tags in the flac and opus formats. As far as I know, APEv2 and m4a tags do not officially have an "original" datetime or year tag key, and support already exists for ID3 with the  `TDOR` key.
Somewhat related, gme and openmpt have date fields in their metadata. Should those be extracted? I rarely see those fields populated in the files I have, so maybe it's best to keep it as is.