### PR TITLE
Scale tooltip height with current gui.scale

### DIFF
--- a/src/tauon/t_modules/t_main.py
+++ b/src/tauon/t_modules/t_main.py
@@ -22034,6 +22034,7 @@ class ToolTip:
 			self.x = x
 			self.y = y
 			self.w = self.ddt.get_text_w(text, self.font) + 20 * self.gui.scale
+			self.h = 24 * self.gui.scale
 
 		self.called = True
 


### PR DESCRIPTION
## Summary

`ToolTip.h` was captured once in `__init__` as `24 * self.gui.scale`, while `ToolTip.w` is rebuilt on every `test()` call. When the GUI scale changes after init (for example on a HIDPI display where scaling resolves to 200% after startup), the tooltip width tracks the current scale but the height stays at the init-time value. The background rect then covers roughly half the expected height, with the text positioned at the current scale -- which matches the screenshot in #1018 where the repeat/shuffle tooltips show the progress bar bleeding through the lower half.

## Fix

Recompute `self.h` alongside `self.w` inside `ToolTip.test()`. Both values are rebuilt on every new tooltip, so they always use the current `self.gui.scale`.

```python
self.w = self.ddt.get_text_w(text, self.font) + 20 * self.gui.scale
self.h = 24 * self.gui.scale   # new
```

One-line addition. The init-time assignment stays in place so `self.h` has a starting value before the first `test()` call.

## Testing

The fix is a mechanical scale propagation; there is no unit test harness for `ToolTip` in the codebase. Python syntax was verified with `python3 -m py_compile src/tauon/t_modules/t_main.py`. The bug was already confirmed reproducible by @C0rn3j on master in #1018.

Fixes #1018

---

This contribution was developed with AI assistance (Claude Code).
