### PR TITLE
Prefer using synced lyrics on MPRIS when available and refresh MPRIS after Subsonic lyrics fetching logic.

### DIFF
--- a/src/tauon/t_modules/t_dbus.py
+++ b/src/tauon/t_modules/t_dbus.py
@@ -129,7 +129,7 @@ class MPRIS(dbus.service.Object):
 				"xesam:albumArtist": dbus.Array([track.album_artist]),
 				"xesam:artist": dbus.Array([track.artist]),
 				"xesam:title": track.title,
-				"xesam:asText": track.lyrics,
+				"xesam:asText": track.synced if track.synced else track.lyrics,
 				"xesam:autoRating": star_count2(self.tauon.star_store.get(track.index)),
 				"xesam:composer": dbus.Array([track.composer]),
 				"tauon:loved": self.tauon.love(False, track.index),

--- a/src/tauon/t_modules/t_subsonic.py
+++ b/src/tauon/t_modules/t_subsonic.py
@@ -265,6 +265,7 @@ class SubsonicService:
 					self.tauon.lyrics_ren_mini.to_reload = True
 					self.tauon.timed_lyrics_ren.index = -1
 					self.pctl.notify_change()
+					self.pctl.notify_update()
 			except Exception:
 				logging.exception("Failed to scan lyrics from Subsonic server")
 			finally:


### PR DESCRIPTION
Fixes a related problem with #2111.

Two small changes to fix synced lyrics not appearing through MPRIS for Subsonic streams.

For local files, synced (LRC) lyrics are read from embedded tags or .lrc files and stored in track.synced, so MPRIS shows them correctly. But for Subsonic/Navidrome, the structured lyrics API returns plain text and LRC content as separate values. Tauon was putting them into track.lyrics (plain) and track.synced (LRC), respectively. Since MPRIS only reads track.lyrics, synced lyrics were lost.

Fix 1: In t_dbus.py, prefer track.synced over track.lyrics when publishing MPRIS metadata, so timestamped lyrics show regardless of source. This is a global fix that applies to any provider populating track.synced.

Fix 2: In t_subsonic.py, call notify_update() after the async lyrics fetch completes, so MPRIS consumers pick up newly fetched lyrics immediately, without weird interactions when switching tracks too fast.